### PR TITLE
Add split_digest option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# vim artifacts
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ plug PlugHMouse,
     json_decoder: Poison
   ],
   hash_algo: :md5,
-  digest: fn string -> Base.encode16(string) end
+  digest: fn string -> Base.encode16(string) end,
+  split_digest: true
 ```
 
 ### validate (mandatory)
@@ -144,6 +145,26 @@ for `:crypto.hmac` are usable.
 ### digest (optional, default: Base.encode64/2)
 
 You can define your own encoding function.
+
+### split_digest (optional, default: `false`)
+
+Determines whether the digest of the request is in the format:
+
+```
+header_name: algo=digest
+eg. X-Hub-Signature: sha1=7d38cdd689735b008b3c702edd92eea23791c5f6
+```
+
+Or:
+
+```
+header_name: digest
+eg. X-Shopify-Hmac-SHA256: fTjN1olzWwCLPHAu3ZLuojeRxfY=
+```
+
+If `split_digest` is set to `true` then the first form will be assumed and the value will be split at the equals sign, with the latter part being taken as the digest. If it is `false` then the second form will be assumed and the full value will be considered the digest.
+
+**Note**: Currently this feature does not use the first half of the value as the hash algorithm, you still have to define the algorithm manually with `hash_algo`.
 
 ### plug_parsers (optional, all values for Plug.Parsers options are allowed)
 

--- a/lib/plug_hmouse.ex
+++ b/lib/plug_hmouse.ex
@@ -139,7 +139,7 @@ defmodule PlugHMouse do
 
   defp split_hash(hash, true) do
     hash
-    |> String.split("=")
+    |> String.split("=", parts: 2)
     |> Enum.at(1)
   end
   defp split_hash(hash, _), do: hash

--- a/lib/plug_hmouse.ex
+++ b/lib/plug_hmouse.ex
@@ -77,7 +77,7 @@ defmodule PlugHMouse do
 
       conn
       |> Plug.Parsers.call(Plug.Parsers.init(opts[:plug_parsers] ++ opts))
-      |> get_hashes(opts[:validate])
+      |> get_hashes(opts[:validate], opts[:b16_digest], opts[:split_digest])
       |> compare_hashes()
       |> halt_or_pipe_through(opts)
     else
@@ -128,14 +128,30 @@ defmodule PlugHMouse do
   defp is_path?([":" <> _url_param | rest_path_1], [_ | rest_path_2]), do: is_path?(rest_path_1, rest_path_2)
   defp is_path?(_, _), do: false
 
-  defp get_hashes(conn, {header_key, secret_key}) do
+  defp get_hashes(conn, {header_key, secret_key}, b16 \\ false, split \\ false) do
     case List.keyfind(conn.req_headers, header_key, 0) do
       {^header_key, hash} ->
-        {:ok, conn, get_hmouse_hash(conn), hash}
+        {:ok, conn, get_hmouse_hash(conn), clean_hash(hash, b16, split)}
       nil ->
         {:ok, conn, get_hmouse_hash(conn), nil}
     end
   end
+
+  defp clean_hash(hash, b16, true) do
+    # in case of algo=digest format
+    hash
+    |> String.split("=")
+    |> Enum.at(1)
+    |> clean_hash(b16, false)
+  end
+  defp clean_hash(hash, true, _) do
+    # in case hash comes as hex string
+    case Base.decode16(hash, case: :mixed) do
+      {:ok, bin_str} -> Base.encode64(bin_str)
+      :error -> nil
+    end
+  end
+  defp clean_hash(hash, _, _), do: hash
 
   defp get_hmouse_hash(%{private: %{plug_hmouse_hashed_body: hash}}), do: hash
   defp get_hmouse_hash(_), do: "empty"


### PR DESCRIPTION
Sometimes digests come in the form:

```
header: algorithm=digest
eg. X-Hub-Signature: sha1=7d38cdd689735b008b3c702edd92eea23791c5f6
```

Which the library didn't previously support. This pull request adds a flag `split_digest` that when set to `true` will split the value of the header at the first '=' and use the second part of it as the digest. It's possible to extend this in future to automatically recognise what hashing algorithm is being used, but this PR doesn't include that feature.

This change was inspired by using the library to recognise the HMACs sent by [GitHub webhooks](https://developer.github.com/webhooks/).

See #1 for more details.